### PR TITLE
fix update batch file for setting mirror

### DIFF
--- a/一键更新仓库.bat
+++ b/一键更新仓库.bat
@@ -3,16 +3,6 @@
 SETLOCAL enableextensions enabledelayedexpansion
 chcp 65001 >NUL
 
-REM 检查参数，如果不为空则只运行特定函数
-IF "x%1" == "x" GOTO START
-CALL :%1
-
-ENDLOCAL
-EXIT /b %errorlevel%
-
-
-:START
-
 REM 本地目录，如果当前目录有.git文件夹的存在，则不使用此目录
 SET LocalFolder=FactoryBluePrints
 
@@ -27,6 +17,16 @@ SET MinGitFolder=%ALLUSERSPROFILE%\MinGit
 
 REM MinGit版本号
 SET MinGitVersion=2.52.0
+
+REM 检查参数，如果不为空则只运行特定函数
+IF "x%1" == "x" GOTO START
+CALL :%1
+
+ENDLOCAL & SET "GIT_PATH=%GIT_PATH%"
+EXIT /b %errorlevel%
+
+
+:START
 
 CALL :SETUP_MINGIT
 IF %errorlevel% NEQ 0 (


### PR DESCRIPTION
修复问题:

1. `设置镜像.bat`没有正确找到Git路径
根因: setlocal后没有endlocal导致GIT_PATH变量丢失

2. 通过`设置镜像.bat`无法正确安装MinGit
根因: MinGit相关变量没有暴露给call的流程